### PR TITLE
Fix assert_param(IS_RCC_PERIPHCLOCK(PeriphClkInit->PeriphClockSelection)); #37

### DIFF
--- a/Drivers/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_rcc_ex.h
+++ b/Drivers/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_rcc_ex.h
@@ -65,7 +65,7 @@ extern "C" {
 #else
 #define RCC_PERIPHCLOCK_ALL             (RCC_PERIPHCLK_USART1 | RCC_PERIPHCLK_I2C1 | RCC_PERIPHCLK_LPTIM1 | \
                                          RCC_PERIPHCLK_LPTIM2 | RCC_PERIPHCLK_RNG | RCC_PERIPHCLK_ADC | \
-                                         RCC_PERIPHCLK_RTC | RCC_PERIPHCLK_RFWAKEUP)
+                                         RCC_PERIPHCLK_RTC | RCC_PERIPHCLK_RFWAKEUP | RCC_PERIPHCLK_CLK48SEL)
 #endif
 
 /**


### PR DESCRIPTION
for https://github.com/STMicroelectronics/STM32CubeWB/issues/37

fix missing RCC_PERIPHCLK_CLK48SEL
For RNG module used CLK48.
Fix assert_param for this param if defined USE_FULL_ASSERT

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/STM32CubeWB/blob/master/CONTRIBUTING.md) file.
