### PR TITLE
Fix unused variable warnings

### DIFF
--- a/Drivers/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_exti.c
+++ b/Drivers/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_exti.c
@@ -530,6 +530,9 @@ void HAL_EXTI_IRQHandler(EXTI_HandleTypeDef *hexti)
   */
 uint32_t HAL_EXTI_GetPending(EXTI_HandleTypeDef *hexti, uint32_t Edge)
 {
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(Edge);
+
   __IO uint32_t *regaddr;
   uint32_t regval;
   uint32_t linepos;
@@ -566,6 +569,9 @@ uint32_t HAL_EXTI_GetPending(EXTI_HandleTypeDef *hexti, uint32_t Edge)
   */
 void HAL_EXTI_ClearPending(EXTI_HandleTypeDef *hexti, uint32_t Edge)
 {
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(Edge);
+
   __IO uint32_t *regaddr;
   uint32_t maskline;
   uint32_t offset;

--- a/Drivers/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_utils.c
+++ b/Drivers/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_utils.c
@@ -23,7 +23,7 @@
 #ifdef  USE_FULL_ASSERT
 #include "stm32_assert.h"
 #else
-#define assert_param(expr) ((void)0U)
+#define assert_param(expr) ((void)(expr))
 #endif
 
 /** @addtogroup STM32WBxx_LL_Driver


### PR DESCRIPTION
Signed-off-by: Julien Gros <gros.julien@gmail.com>
This fixes the following issue: https://github.com/STMicroelectronics/STM32CubeWB/issues/48