### PR TITLE
flash: fixup for wb10cc chips

### DIFF
--- a/Drivers/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_flash.h
+++ b/Drivers/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_flash.h
@@ -855,7 +855,7 @@ HAL_StatusTypeDef  FLASH_WaitForLastOperation(uint32_t Timeout);
 #define FLASH_END_ADDR                          (FLASH_BASE + FLASH_SIZE - 1U)
 
 #define FLASH_BANK_SIZE                         FLASH_SIZE   /*!< FLASH Bank Size */
-#if defined(STM32WB15xx) || defined(STM32WB1Mxx)
+#if defined(STM32WB15xx) || defined(STM32WB10xx) || defined(STM32WB1Mxx)
 #define FLASH_PAGE_SIZE                         0x00000800U  /*!< FLASH Page Size, 2 KBytes */
 #else
 #define FLASH_PAGE_SIZE                         0x00001000U  /*!< FLASH Page Size, 4 KBytes */
@@ -863,7 +863,7 @@ HAL_StatusTypeDef  FLASH_WaitForLastOperation(uint32_t Timeout);
 #define FLASH_PAGE_NB                           (FLASH_SIZE / FLASH_PAGE_SIZE)
 #define FLASH_TIMEOUT_VALUE                     1000U        /*!< FLASH Execution Timeout, 1 s */
 
-#if defined(STM32WB15xx) || defined(STM32WB1Mxx)
+#if defined(STM32WB15xx) || defined(STM32WB10xx) || defined(STM32WB1Mxx)
 #define FLASH_PCROP_GRANULARITY_OFFSET          10U                                      /*!< FLASH Code Readout Protection granularity offset */
 #define FLASH_PCROP_GRANULARITY                 (1UL << FLASH_PCROP_GRANULARITY_OFFSET)  /*!< FLASH Code Readout Protection granularity, 1 KBytes */
 #else

--- a/Drivers/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_flash.h
+++ b/Drivers/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_flash.h
@@ -564,7 +564,7 @@ typedef struct
 #define SRAM2B_START_SECURE_ADDR_1       (SRAM2B_BASE + 0x0400U)  /*  When in secure mode (SRAM2B_BASE + 0x0400) -> SRAM2B_END_ADDR is accessible only by M0 Plus  */
 #define SRAM2B_START_SECURE_ADDR_2       (SRAM2B_BASE + 0x0800U)  /*  When in secure mode (SRAM2B_BASE + 0x0800) -> SRAM2B_END_ADDR is accessible only by M0 Plus  */
 #define SRAM2B_START_SECURE_ADDR_3       (SRAM2B_BASE + 0x0C00U)  /*  When in secure mode (SRAM2B_BASE + 0x0C00) -> SRAM2B_END_ADDR is accessible only by M0 Plus  */
-#if !defined(STM32WB15xx) && !defined(STM32WB1Mxx)
+#if !defined(STM32WB15xx && !defined(STM32WB10xx)) && !defined(STM32WB1Mxx)
 #define SRAM2B_START_SECURE_ADDR_4       (SRAM2B_BASE + 0x1000U)  /*  When in secure mode (SRAM2B_BASE + 0x1000) -> SRAM2B_END_ADDR is accessible only by M0 Plus  */
 #define SRAM2B_START_SECURE_ADDR_5       (SRAM2B_BASE + 0x1400U)  /*  When in secure mode (SRAM2B_BASE + 0x1400) -> SRAM2B_END_ADDR is accessible only by M0 Plus  */
 #define SRAM2B_START_SECURE_ADDR_6       (SRAM2B_BASE + 0x1800U)  /*  When in secure mode (SRAM2B_BASE + 0x1800) -> SRAM2B_END_ADDR is accessible only by M0 Plus  */


### PR DESCRIPTION
hal flash header is not properly handling STM32WB10 chips - checks are missing