### PR TITLE
Fix STOPF timeout not working in I2C_IsErrorOccurred

### DIFF
--- a/Drivers/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_i2c.c
+++ b/Drivers/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_i2c.c
@@ -6857,14 +6857,10 @@ static HAL_StatusTypeDef I2C_IsErrorOccurred(I2C_HandleTypeDef *hi2c, uint32_t T
             /* Check for the Timeout */
             if ((HAL_GetTick() - tickstart) > I2C_TIMEOUT_STOPF)
             {
-              hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
-              hi2c->State = HAL_I2C_STATE_READY;
-              hi2c->Mode = HAL_I2C_MODE_NONE;
-
-              /* Process Unlocked */
-              __HAL_UNLOCK(hi2c);
+              error_code |= HAL_I2C_ERROR_TIMEOUT;
 
               status = HAL_ERROR;
+              break;
             }
           }
         }


### PR DESCRIPTION
When STOPF is never set, the I2C_IsErrorOccurred function looped forever, even after reaching I2C_TIMEOUT_STOPF
This commit fixes this issue

### WARNING ###
This issue is present in multiple HAL driver repositories and processor CubeMX packages, and sometimes it has been fixed in the HAL driver repo but not yet in the CubeMX repo. This list is not exhaustive:
- [stm32h7xx_hal_driver](https://github.com/STMicroelectronics/stm32h7xx_hal_driver/blob/master/Src/stm32h7xx_hal_i2c.c#L6604)
- [stm32u5xx_hal_driver](https://github.com/STMicroelectronics/stm32u5xx_hal_driver/blob/main/Src/stm32u5xx_hal_i2c.c#L7010)
- [STM32CubeG4](https://github.com/STMicroelectronics/STM32CubeG4/blob/master/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_i2c.c#L6583) but fixed in [STM32G4xx_HAL_Driver](https://github.com/STMicroelectronics/stm32g4xx_hal_driver/blob/master/Src/stm32g4xx_hal_i2c.c#L6856)
