### PR TITLE
Added I2C_OTHER_AND_NEXT_FRAME to allow consecutive transmit/receive with restart

### DIFF
--- a/Drivers/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_i2c.h
+++ b/Drivers/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_i2c.h
@@ -314,6 +314,7 @@ typedef  void (*pI2C_AddrCallbackTypeDef)(I2C_HandleTypeDef *hi2c, uint8_t Trans
  */
 #define  I2C_OTHER_FRAME                (0x000000AAU)
 #define  I2C_OTHER_AND_LAST_FRAME       (0x0000AA00U)
+#define  I2C_OTHER_AND_NEXT_FRAME       (0x00AA0000U)
 /**
   * @}
   */
@@ -781,8 +782,9 @@ uint32_t             HAL_I2C_GetError(const I2C_HandleTypeDef *hi2c);
                                                    ((REQUEST) == I2C_LAST_FRAME_NO_STOP)   || \
                                                    IS_I2C_TRANSFER_OTHER_OPTIONS_REQUEST(REQUEST))
 
-#define IS_I2C_TRANSFER_OTHER_OPTIONS_REQUEST(REQUEST) (((REQUEST) == I2C_OTHER_FRAME)     || \
-                                                        ((REQUEST) == I2C_OTHER_AND_LAST_FRAME))
+#define IS_I2C_TRANSFER_OTHER_OPTIONS_REQUEST(REQUEST) (((REQUEST) == I2C_OTHER_FRAME)           || \
+                                                        ((REQUEST) == I2C_OTHER_AND_LAST_FRAME)  || \
+                                                        ((REQUEST) == I2C_OTHER_AND_NEXT_FRAME))
 
 #define I2C_RESET_CR2(__HANDLE__)                 ((__HANDLE__)->Instance->CR2 &= \
                                                    (uint32_t)~((uint32_t)(I2C_CR2_SADD   | I2C_CR2_HEAD10R | \

--- a/Drivers/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_i2c.c
+++ b/Drivers/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_i2c.c
@@ -146,6 +146,8 @@
                               with option I2C_FIRST_FRAME then I2C_OTHER_FRAME.
                             Then usage of this option I2C_OTHER_AND_LAST_FRAME at the last frame to help automatic
                             generation of STOP condition.
+                            Usage of I2C_OTHER_AND_NEXT_FRAME allow to manage a sequence with a reset condition
+                            and continue to send bytes in the same direction.
 
       (+) Different sequential I2C interfaces are listed below:
       (++) Sequential transmit in master I2C mode an amount of data in non-blocking mode using
@@ -7295,6 +7297,10 @@ static void I2C_ConvertOtherXferOptions(I2C_HandleTypeDef *hi2c)
   else if (hi2c->XferOptions == I2C_OTHER_AND_LAST_FRAME)
   {
     hi2c->XferOptions = I2C_FIRST_AND_LAST_FRAME;
+  }
+  else if (hi2c->XferOptions == I2C_OTHER_AND_NEXT_FRAME)
+  {
+    hi2c->XferOptions = I2C_FIRST_AND_NEXT_FRAME;
   }
   else
   {


### PR DESCRIPTION
During the development of [IQS7222C](https://www.azoteq.com/images/stories/pdf/iqs7222c_datasheet_v1.9.pdf) driver, I was limited by the state machine of HAL_I2C in sequential transmit mode.

Indeed, the chip reconfigure itself at each STOP event received.
To achieve a correct configuration, the master shall send frames with only restarts between reads/writes.

This lead to this situation where after a first write, we need to send:
- a restart condition followed by address, and 1 or 2 bytes for the register address
- the 2 bytes data without any restart condition

In the actual code, this can't be achieved since I2C_OTHER_FRAME don't set the CR2_RELOAD register what leading to TCR event flag rising at the 2nd write (2bytes of data).

Adding I2C_OTHER_AND_NEXT_FRAME fix this issue.

The subsequent failing code:
```
uint8_t msbFirstRegAddr[2] = {0x80, 0x00};
uint8_t lsbFirstRegValue[2] = {0xFE, 0xCA};
HAL_I2C_Master_Seq_Transmit_IT(hi2c, DEV_ADDR, msbFirstRegAddr, 2, I2C_OTHER_FRAME);
HAL_I2C_Master_Seq_Transmit_IT(hi2c, DEV_ADDR, lsbFirstRegValue, sizeof(lsbFirstRegValue), I2C_LAST_FRAME_NO_STOP); // TCR will raise too early because RELOAD value hasn't be set before
```

become:
```
uint8_t msbFirstRegAddr[2] = {0x80, 0x00};
uint8_t lsbFirstRegValue[2] = {0xFE, 0xCA};
HAL_I2C_Master_Seq_Transmit_IT(hi2c, DEV_ADDR, msbFirstRegAddr, 2, I2C_OTHER_AND_NEXT_FRAME);
HAL_I2C_Master_Seq_Transmit_IT(hi2c, DEV_ADDR, lsbFirstRegValue, sizeof(lsbFirstRegValue), I2C_LAST_FRAME_NO_STOP); // TCR will raise too early because RELOAD value hasn't be set before
```